### PR TITLE
Fix for URLs that use the rel=alternate that are parsed by SimpleRSS.

### DIFF
--- a/lib/parsers/simple-rss.rb
+++ b/lib/parsers/simple-rss.rb
@@ -74,7 +74,7 @@ module FeedNormalizer
         :last_updated => [:updated, :lastBuildDate, :pubDate, :dc_date],
         :copyright => [:copyright, :rights],
         :authors => [:author, :webMaster, :managingEditor, :contributor],
-        :urls => :link,
+        :urls => [:'link+alternate', :link],
         :description => [:description, :subtitle],
         :ttl => :ttl
       }
@@ -89,7 +89,7 @@ module FeedNormalizer
       # entry elements
       entry_mapping = {
         :date_published => [:pubDate, :published, :dc_date, :issued],
-        :urls => :link,
+        :urls => [:'link+alternate', :link],
         :enclosures => :enclosure,
         :description => [:description, :summary],
         :content => [:content, :content_encoded, :description],


### PR DESCRIPTION
Uses the :link+alternate field for the URL. E.g. 
On inspection of the RFC ( http://www.ietf.org/rfc/rfc4287.txt ) it says (section 
4.2.7.2) :

"
atom:link elements MAY have a "rel" attribute that indicates the link
   relation type.  If the "rel" attribute is not present, the link
   element MUST be interpreted as if the link relation type is
   "alternate".
"

see: http://code.google.com/p/feed-normalizer/issues/detail?id=30#c6
