### PR TITLE
Fixes for 1.9.x

### DIFF
--- a/lib/structures.rb
+++ b/lib/structures.rb
@@ -11,7 +11,9 @@ module FeedNormalizer
     # Object contains an array called 'alphas', which looks like [:a, :b, :c].
     # Call object.alpha and :a is returned.
     def method_missing(name, *args)
-      return self.send(:"#{name}s").first rescue super(name, *args)
+      plural_name = :"#{name}s"
+      return self.send(plural_name).first if respond_to?(plural_name)
+      super(name, *args)
     end
 
     def respond_to?(x, y=false)

--- a/test/test_feednormalizer.rb
+++ b/test/test_feednormalizer.rb
@@ -14,7 +14,7 @@ class FeedNormalizerTest < Test::Unit::TestCase
   # Load up the xml files
   Dir.open(data_dir).each do |fn|
     next unless fn =~ /[.]xml$/
-    XML_FILES[fn.scan(/(.*)[.]/).to_s.to_sym] = File.read(data_dir + "/#{fn}")
+    XML_FILES[File.basename(fn, File.extname(fn)).to_sym] = File.read(data_dir + "/#{fn}")
   end
 
   def test_basic_parse

--- a/test/test_feednormalizer.rb
+++ b/test/test_feednormalizer.rb
@@ -137,14 +137,6 @@ class FeedNormalizerTest < Test::Unit::TestCase
   def test_method_missing
     assert_raise(NoMethodError) { FeedNormalizer::FeedNormalizer.parse(XML_FILES[:rss20]).nonexistent }
 
-    assert_raise(NoMethodError) do
-      obj = Object.new
-      class << obj
-        include Fn::Singular
-      end
-      obj.foo
-    end
-
     # Another test of Singular's method_missing: sending :flatten to a 2-D array of FeedNormalizer::Entrys
     # causes :to_ary to be sent to the Entrys.
     assert_nothing_raised { [[Fn::Entry.new], [Fn::Entry.new]].flatten }

--- a/test/test_feednormalizer.rb
+++ b/test/test_feednormalizer.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), '../lib')))
 require 'test/unit'
 require 'feed-normalizer'
+require 'yaml'
 
 class FeedNormalizerTest < Test::Unit::TestCase
 

--- a/test/test_feednormalizer.rb
+++ b/test/test_feednormalizer.rb
@@ -135,7 +135,19 @@ class FeedNormalizerTest < Test::Unit::TestCase
   end
 
   def test_method_missing
-    assert_raise(NoMethodError) { Fn::Feed.new(nil).nonexistant }
+    assert_raise(NoMethodError) { FeedNormalizer::FeedNormalizer.parse(XML_FILES[:rss20]).nonexistent }
+
+    assert_raise(NoMethodError) do
+      obj = Object.new
+      class << obj
+        include Fn::Singular
+      end
+      obj.foo
+    end
+
+    # Another test of Singular's method_missing: sending :flatten to a 2-D array of FeedNormalizer::Entrys
+    # causes :to_ary to be sent to the Entrys.
+    assert_nothing_raised { [[Fn::Entry.new], [Fn::Entry.new]].flatten }
   end
 
   def test_clean


### PR DESCRIPTION
Hello. I've been updating a legacy Rails app to use Ruby 1.9, and ran into a stack overflow exception when trying to flatten an array that contained FeedNormalizer::Entry objects.

I discovered that Singular's method_missing recursed infinitely when passed a method whose plural form isn't implemented in the receiving object. In Ruby 1.8, the resulting SystemStackError was caught by the rescue statement modifier, so the super's method_missing was called and raised NoMethodError as expected (after a noticeable pause during the recursion). But in Ruby 1.9, SystemStackError is not a StandardError and thus is not caught by the rescue statement modifier.

This branch also contains a few other fixes to make all the tests pass on Ruby 1.8, and most of them pass on 1.9. There are still 4 failing tests on 1.9, but they are due to other 1.9 compatibility issues.
